### PR TITLE
fix: задать набор правил линтера явно

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,11 @@ package = false
 
 [tool.ruff]
 line-length = 80
-extend-exclude = ["migrations"]
+# settings.py и manage.py это шаблон django-admin, его форму мы не ведём
+extend-exclude = ["migrations", "settings.py", "manage.py"]
+
+[tool.ruff.lint]
+select = ["E", "F", "C90"]
 
 [tool.ruff.lint.per-file-ignores]
 # Django boilerplate stubs


### PR DESCRIPTION
Без `select` ruff берёт набор по умолчанию, а он меняется вместе с версией: в 0.16 добавилась сортировка импортов. Из-за этого PR Dependabot с обновлением ruff (#12) роняет CI на коде, который никто не трогал.

Набор задан такой же, как у остальной python-пачки: `E`, `F`, `C90`. Вместе с ним включается `E501`, поэтому `settings.py` и `manage.py` добавлены в `extend-exclude`: это шаблон `django-admin`, его форму мы не ведём. Точно так же сделано в `python-django-blog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)